### PR TITLE
增加 WallpaperColors 支持

### DIFF
--- a/app/src/main/java/ooo/oxo/apps/earth/EarthWallpaperService.java
+++ b/app/src/main/java/ooo/oxo/apps/earth/EarthWallpaperService.java
@@ -29,6 +29,7 @@ import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.Rect;
+import android.os.Build;
 import android.service.wallpaper.WallpaperService;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -36,8 +37,10 @@ import android.view.SurfaceHolder;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
+import android.app.WallpaperColors;
 
 import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -122,6 +125,15 @@ public class EarthWallpaperService extends WallpaperService {
             if (isVisible()) {
                 draw();
             }
+        }
+
+        @RequiresApi(api = Build.VERSION_CODES.O_MR1)
+        @Override
+        public WallpaperColors onComputeColors() {
+            Bitmap image = Bitmap.createBitmap(1, 1, Bitmap.Config.RGB_565);
+            image.eraseColor(Color.BLACK);
+            // WallpaperColors constructor is broken. Use fromBitmap to create all black colors  https://forum.xda-developers.com/showpost.php?p=74906107&postcount=7
+            return WallpaperColors.fromBitmap(image);
         }
 
         private void draw() {

--- a/wear/src/main/java/ooo/oxo/apps/earth/EarthWatchFaceService.java
+++ b/wear/src/main/java/ooo/oxo/apps/earth/EarthWatchFaceService.java
@@ -18,14 +18,17 @@
 
 package ooo.oxo.apps.earth;
 
+import android.app.WallpaperColors;
 import android.database.ContentObserver;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Canvas;
+import android.graphics.Color;
 import android.graphics.ColorMatrix;
 import android.graphics.ColorMatrixColorFilter;
 import android.graphics.Paint;
 import android.graphics.Rect;
+import android.os.Build;
 import android.support.wearable.watchface.CanvasWatchFaceService;
 import android.support.wearable.watchface.WatchFaceStyle;
 import android.util.Log;
@@ -34,6 +37,7 @@ import android.view.SurfaceHolder;
 import android.view.WindowInsets;
 
 import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
 
 import java.io.FileNotFoundException;
 
@@ -152,6 +156,15 @@ public class EarthWatchFaceService extends CanvasWatchFaceService {
             canvas.drawBitmap(earth, null, region, paint);
 
             earth.recycle();
+        }
+
+        @RequiresApi(api = Build.VERSION_CODES.O_MR1)
+        @Override
+        public WallpaperColors onComputeColors(){
+            Bitmap image = Bitmap.createBitmap(1, 1, Bitmap.Config.RGB_565);
+            image.eraseColor(Color.BLACK);
+            // WallpaperColors constructor is broken. Use fromBitmap to create all black colors  https://forum.xda-developers.com/showpost.php?p=74906107&postcount=7
+            return WallpaperColors.fromBitmap(image);
         }
 
         @Nullable


### PR DESCRIPTION
#13 

从 Android 8.1 开始，系统会获取壁纸的颜色来适配深色 / 浅色主题。Live Wallpaper 没有指定定壁纸颜色的话，就会默认为浅色，显示效果欠佳。

修改之前的效果（从左到右分别是 8.1、9、10）⬇️

![修改之前](https://user-images.githubusercontent.com/1688764/76778701-35712280-67e5-11ea-86a6-9038acccd27c.png)

修改之后的效果 ⬇️

![修改之后](https://user-images.githubusercontent.com/1688764/76778857-78cb9100-67e5-11ea-8a3f-450821712297.png)

在 8.1 和 9 的系统上，整个系统都会变为深色主题，10 上只有 Pixel Launcher 会变，系统 UI 的深浅则由系统设置中的「深色主题」来控制。⬇️

![深色主题](https://user-images.githubusercontent.com/1688764/76779204-ee376180-67e5-11ea-827b-faf591f47b4a.png)

参考链接：https://forum.xda-developers.com/android/apps-games/app-lwp-live-wallpaper-wallpapercolors-t3720622


